### PR TITLE
changed  methodChannelName for fix bug MissingPluginException in Android

### DIFF
--- a/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/FlutterRadioPlayerPlugin.kt
+++ b/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/FlutterRadioPlayerPlugin.kt
@@ -35,7 +35,7 @@ public class FlutterRadioPlayerPlugin: FlutterPlugin, MethodCallHandler, StreamH
     }
 
     const val broadcastActionName = "playback_status"
-    const val methodChannelName = "streaming_audio_player"
+    const val methodChannelName = "flutter_radio_player"
     const val eventChannelName = methodChannelName + "_stream"
 
     var isBound = false


### PR DESCRIPTION
He had been reported several issues of MissingPluginException on Android. This happened because in the interface it is called flutter_radio_player and the android class was waiting for it as streaming_audio_player