### PR TITLE
Added INTERNET and FOREGROUND_SERVICE permission and removing condition causing crash

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="me.sithiramunasinghe.flutter.flutter_radio_player">
+    package="me.sithiramunasinghe.flutter.flutter_radio_player">
+
+    <!--  Permissions for the plugin  -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <!--  Services for the plugin  -->
+    <application android:usesCleartextTraffic="true">
+        <service android:name=".core.StreamingCore"/>
+    </application>
 </manifest>
+

--- a/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/FlutterRadioPlayerPlugin.kt
+++ b/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/FlutterRadioPlayerPlugin.kt
@@ -35,7 +35,7 @@ public class FlutterRadioPlayerPlugin: FlutterPlugin, MethodCallHandler, StreamH
     }
 
     const val broadcastActionName = "playback_status"
-    const val methodChannelName = "streaming_audio_player"
+    const val methodChannelName = "flutter_radio_player"
     const val eventChannelName = methodChannelName + "_stream"
 
     var isBound = false

--- a/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/core/StreamingCore.kt
+++ b/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/core/StreamingCore.kt
@@ -92,21 +92,8 @@ class StreamingCore : Service(), AudioManager.OnAudioFocusChangeListener {
                         stopSelf()
                         PlaybackStatus.STOPPED
                     }
-                    Player.STATE_READY -> if (playWhenReady) {
-                        pushEvent(FLUTTER_RADIO_PLAYER_PLAYING)
-                        PlaybackStatus.PLAYING
-                    } else {
-                        pushEvent(FLUTTER_RADIO_PLAYER_PAUSED)
-                        PlaybackStatus.PAUSED
-                    }
-                    else -> {
-                        if (playbackStatus != PlaybackStatus.ERROR) {
-                            pushEvent(FLUTTER_RADIO_PLAYER_STOPPED)
-                            PlaybackStatus.IDLE
-                        } else {
-                            PlaybackStatus.ERROR
-                        }
-                    }
+                    Player.STATE_READY -> setPlayWhenReady(playWhenReady)
+                    else -> setPlayWhenReady(playWhenReady)
                 }
 
                 logger.info("onPlayerStateChanged: $playbackStatus")
@@ -204,6 +191,17 @@ class StreamingCore : Service(), AudioManager.OnAudioFocusChangeListener {
         player?.release()
 
         super.onDestroy()
+    }
+
+
+    fun setPlayWhenReady(playWhenReady: Boolean): PlaybackStatus {
+        return if (playWhenReady) {
+            pushEvent(FLUTTER_RADIO_PLAYER_PLAYING)
+            PlaybackStatus.PLAYING
+        } else {
+            pushEvent(FLUTTER_RADIO_PLAYER_PAUSED)
+            PlaybackStatus.PAUSED
+        }
     }
 
     override fun onAudioFocusChange(audioFocus: Int) {


### PR DESCRIPTION
The music service could not initialize because the permission of INTERNET and FOREGROUND_SERVICE was required.

After adding these permissions another error occurred. It was checking if there was an error inside the EventListener when even the variable playbackStatus