### PR TITLE
Fixes iOS paused event thrown even when playWhenReady is set to true

### DIFF
--- a/ios/Classes/core/StreamingCore.swift
+++ b/ios/Classes/core/StreamingCore.swift
@@ -222,13 +222,11 @@ class StreamingCore : NSObject, AVPlayerItemMetadataOutputPushDelegate {
                 
                 if newStatus == .readyToPlay {
                     print("Observer: Ready to play...")
-                    if (!isPlaying()) {
-                        if (self.playWhenReady) {
-                            play()
-                        }
-                        pushEvent(eventName: Constants.FLUTTER_RADIO_PAUSED)
-                    } else {
-                        pushEvent(eventName: Constants.FLUTTER_RADIO_PLAYING)
+                    pushEvent(eventName: isPlaying()
+                                ? Constants.FLUTTER_RADIO_PLAYING
+                                : Constants.FLUTTER_RADIO_PAUSED)
+                    if !isPlaying() && self.playWhenReady {
+                        play()
                     }
                 }
                 


### PR DESCRIPTION
Fixes #35 
The FLUTTER_RADIO_PAUSED event was dispatched after the play() method when having playWhenReady set to true.
So the playing event is quickly overwritten by the paused event.
Code change should be logically the same as this:
```swift
if (!isPlaying()) {
    pushEvent(eventName: Constants.FLUTTER_RADIO_PAUSED) // Moved this call up so its called before the play function
    if (self.playWhenReady) {
        play()
    }
} else {
    pushEvent(eventName: Constants.FLUTTER_RADIO_PLAYING)
}
```