### PR TITLE
Fixes foreground service not stopped when app gets destroyed

### DIFF
--- a/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/FlutterRadioPlayerPlugin.kt
+++ b/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/FlutterRadioPlayerPlugin.kt
@@ -3,8 +3,14 @@ package me.sithiramunasinghe.flutter.flutter_radio_player
 import android.content.*
 import android.os.IBinder
 import androidx.annotation.NonNull
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.embedding.engine.plugins.lifecycle.FlutterLifecycleAdapter;
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.EventChannel.EventSink
@@ -20,7 +26,7 @@ import me.sithiramunasinghe.flutter.flutter_radio_player.core.enums.PlayerMethod
 import java.util.logging.Logger
 
 /** FlutterRadioPlayerPlugin */
-public class FlutterRadioPlayerPlugin : FlutterPlugin, MethodCallHandler {
+public class FlutterRadioPlayerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private var logger = Logger.getLogger(FlutterRadioPlayerPlugin::javaClass.name)
 
     private lateinit var methodChannel: MethodChannel
@@ -280,5 +286,16 @@ public class FlutterRadioPlayerPlugin : FlutterPlugin, MethodCallHandler {
                 mEventMetaDataSink?.success(receivedMeta)
             }
         }
+    }
+
+    override fun onAttachedToActivity(p0: ActivityPluginBinding) {
+        val lifecycle: Lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(p0);
+        lifecycle.addObserver(object : LifecycleObserver {
+            @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+            fun onDestroy() {
+                stop();
+                logger.info("Stopping foregroundservice since app is about to get destroyed")
+            }
+        })
     }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -62,6 +62,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.11"
   flutter_radio_player:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -55,6 +55,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: "direct main"
+    description:
+      name: flutter_plugin_android_lifecycle
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.11"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_plugin_android_lifecycle: ^1.0.11
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This issue is android-only.
Using flutter plugin flutter_plugin_android_lifecycle we can register a listener for app destroy event.
When app gets destroyed, we want the foregroundservice to stop. Otherwise wenn we reopen the app, the plugin cannot connect to the running service and gets buggy.

We have to do this logic in platform-specific code, since _channel.invokeMethod wont work on flutter side when trying to call stop via WidgetsBindingObserver. See issue https://github.com/flutter/flutter/issues/65538 and related issue https://github.com/Sithira/FlutterRadioPlayer/issues/21.