### PR TITLE
Fixes shrinked property names in release mode

### DIFF
--- a/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/core/data/FRPCurrentSource.kt
+++ b/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/core/data/FRPCurrentSource.kt
@@ -1,6 +1,11 @@
 package me.sithiramunasinghe.flutter.flutter_radio_player.core.data
 
+import com.google.gson.annotations.SerializedName
+
 data class FRPCurrentSource(
+    @SerializedName("title")
     val title: String? = null,
+
+    @SerializedName("description")
     val description: String? = null
 )

--- a/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/core/data/FRPVolumeChangeEvent.kt
+++ b/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/core/data/FRPVolumeChangeEvent.kt
@@ -1,3 +1,8 @@
 package me.sithiramunasinghe.flutter.flutter_radio_player.core.data
 
-data class FRPVolumeChangeEvent(val volume: Float = 0.5F)
+import com.google.gson.annotations.SerializedName
+
+data class FRPVolumeChangeEvent(
+        @SerializedName("volume")
+        val volume: Float = 0.5F
+)

--- a/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/core/events/FRPPlayerEvent.kt
+++ b/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/core/events/FRPPlayerEvent.kt
@@ -1,13 +1,22 @@
 package me.sithiramunasinghe.flutter.flutter_radio_player.core.events
 
+import com.google.gson.annotations.SerializedName
 import me.sithiramunasinghe.flutter.flutter_radio_player.core.data.FRPCurrentSource
-import me.sithiramunasinghe.flutter.flutter_radio_player.core.data.FRPIcyMetaData
 import me.sithiramunasinghe.flutter.flutter_radio_player.core.data.FRPVolumeChangeEvent
 
 data class FRPPlayerEvent(
+    @SerializedName("type")
     val type: String? = null,
+
+    @SerializedName("currentSource")
     val currentSource: FRPCurrentSource? = null,
+
+    @SerializedName("volumeChangeEvent")
     val volumeChangeEvent: FRPVolumeChangeEvent? = null,
+
+    @SerializedName("playbackStatus")
     val playbackStatus: String? = null,
+
+    @SerializedName("icyMetaDetails")
     val icyMetaDetails: String? = null
 )


### PR DESCRIPTION
in release, flutter or gson shrinks the property names of the events while serializing. 
Then the serialized JSON looks like this: `{"a": "flutter_radio_playing", "e": "Cliff Richard - Living Doll (02:34)"}` (So the keys are wrong)
The Annotations should ensure the keys are our expected ones.