### PR TITLE
Set foreground media player title on Android when available.

### DIFF
--- a/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/FlutterRadioPlayerPlugin.kt
+++ b/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/FlutterRadioPlayerPlugin.kt
@@ -110,7 +110,8 @@ class FlutterRadioPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
                         if (it.title.isNullOrEmpty()) {
                             mediaMeta.setArtist(getAppName())
                         } else {
-                            mediaMeta.setArtist(it.title)
+                            mediaMeta.setTitle(it.title)
+                            mediaMeta.setArtist(getAppName())
                         }
                         if (!it.artwork.isNullOrEmpty()) {
                             if ((it.artwork!!.contains("http") || it.artwork!!.contains("https"))) {


### PR DESCRIPTION
This reflects the way the title is set on the iOS side.

Compare the Swift code
https://github.com/Sithira/FlutterRadioPlayer/blob/9110d5df31974eca61819b7cd558a34c6c39be6b/ios/Classes/core/PlaybackService.swift#L58-L63
and the old Android Kotlin code
https://github.com/Sithira/FlutterRadioPlayer/blob/9110d5df31974eca61819b7cd558a34c6c39be6b/android/src/main/kotlin/me/sithiramunasinghe/flutter/flutter_radio_player/FlutterRadioPlayerPlugin.kt#L110-L114

Before this, when there was a title provided,
the title would be unset, and the artists would get the title.